### PR TITLE
Muestra versión de la aplicación en la interfaz

### DIFF
--- a/index.html
+++ b/index.html
@@ -325,6 +325,13 @@
         </div>
     </div>
 
+    <div id="app-version" class="fixed bottom-2 right-2 text-xs text-gray-500"></div>
+
+    <script type="module">
+        import { APP_VERSION } from './js/version.js';
+        document.getElementById('app-version').textContent = `v${APP_VERSION}`;
+    </script>
+
     <script type="module" src="js/app.js"></script>
 
 </body>

--- a/js/version.js
+++ b/js/version.js
@@ -1,0 +1,2 @@
+// Cambiar el número de versión con cada actualización
+export const APP_VERSION = '1.0';


### PR DESCRIPTION
## Resumen
- Añade un indicador de versión fijo en la esquina inferior de la interfaz.
- Define el número de versión inicial (1.0) en un módulo independiente para futuras actualizaciones.

## Pruebas
- `npm test` *(falla: no se encontró package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cf4058aa0832d82baf2443bae2873