### PR TITLE
Hide loading screen after init

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3,6 +3,13 @@ import { initInventory } from './inventory.js';
 import { initOrders } from './orders.js';
 import { initHistory } from './history.js';
 import { APP_VERSION } from './version.js';
+import { getDOM } from './elements.js';
+
+export function initApp() {
+  const { el } = getDOM();
+  el.loadingView.classList.add('hidden');
+  el.loginView.classList.remove('hidden');
+}
 
 document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('app-version').textContent = `v${APP_VERSION}`;
@@ -10,4 +17,5 @@ document.addEventListener('DOMContentLoaded', () => {
   initInventory();
   initOrders();
   initHistory();
+  initApp();
 });

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -1,0 +1,26 @@
+test('initApp hides loading and shows login view', async () => {
+  const createEl = (cls = '') => ({
+    classList: {
+      classes: new Set(cls.split(' ').filter(Boolean)),
+      add(c) { this.classes.add(c); },
+      remove(c) { this.classes.delete(c); },
+      contains(c) { return this.classes.has(c); }
+    }
+  });
+
+  const elements = {
+    'loading-view': createEl(),
+    'login-view': createEl('hidden')
+  };
+
+  global.document = {
+    getElementById: (id) => elements[id],
+    querySelectorAll: () => [],
+    addEventListener: () => {}
+  };
+
+  const { initApp } = await import('../js/app.js');
+  initApp();
+  expect(elements['loading-view'].classList.contains('hidden')).toBe(true);
+  expect(elements['login-view'].classList.contains('hidden')).toBe(false);
+});


### PR DESCRIPTION
## Summary
- hide loading screen and reveal login view after DOM loads
- add test for app initialization to ensure loading screen is hidden

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d07cccd44832d94ad08a29b8917c7