### PR TITLE
Implement email/password authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/js/app.js
+++ b/js/app.js
@@ -11,11 +11,33 @@ export function initApp() {
   el.loginView.classList.remove('hidden');
 }
 
+export function setupMenu() {
+  const { allViews, el } = getDOM();
+  const show = (view) => {
+    allViews.forEach(v => v.classList.add('hidden'));
+    view.classList.remove('hidden');
+  };
+
+  el.startNewInventoryBtn.addEventListener('click', () => show(el.setup));
+  el.continueInventoryBtn.addEventListener('click', () => show(el.setup));
+  el.makeOrderBtn.addEventListener('click', () => show(el.setupOrder));
+  el.continueOrderBtn.addEventListener('click', () => show(el.setupOrder));
+  el.consumptionReportBtn.addEventListener('click', () => show(el.consumptionSetup));
+  el.historyBtn.addEventListener('click', () => show(el.history));
+  el.manageItemsBtn.addEventListener('click', () => show(el.manageItems));
+
+  el.backToMenuFromHistoryBtn.addEventListener('click', () => show(el.mainMenu));
+  el.backToMenuFromManageBtn.addEventListener('click', () => show(el.mainMenu));
+  el.backToMenuFromSelectInvBtn.addEventListener('click', () => show(el.mainMenu));
+  el.backToMenuFromConsumptionBtn.addEventListener('click', () => show(el.mainMenu));
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('app-version').textContent = `v${APP_VERSION}`;
   initAuth();
   initInventory();
   initOrders();
   initHistory();
+  setupMenu();
   initApp();
 });

--- a/js/auth.js
+++ b/js/auth.js
@@ -1,5 +1,67 @@
-export function initAuth() {
-  console.log('Auth initialized');
+export async function initAuth() {
+  const { getDOM } = await import('./elements.js');
+  const {
+    auth,
+    signInWithEmailAndPassword,
+    createUserWithEmailAndPassword,
+    signOut,
+    onAuthStateChanged,
+  } = await import('./firebase.js');
+  const { runtime } = await import('./state.js');
+
+  const { el } = getDOM();
+
+  const updateMode = () => {
+    if (runtime.isLoginMode) {
+      el.authTitle.textContent = 'Iniciar Sesión';
+      el.authActionBtn.textContent = 'Iniciar Sesión';
+      el.authToggleText.textContent = '¿No tienes cuenta?';
+      el.authToggleBtn.textContent = 'Regístrate';
+    } else {
+      el.authTitle.textContent = 'Regístrate';
+      el.authActionBtn.textContent = 'Crear Cuenta';
+      el.authToggleText.textContent = '¿Ya tienes cuenta?';
+      el.authToggleBtn.textContent = 'Inicia Sesión';
+    }
+    el.loginError.textContent = '';
+  };
+
+  el.authToggleBtn.addEventListener('click', () => {
+    runtime.isLoginMode = !runtime.isLoginMode;
+    updateMode();
+  });
+
+  el.authActionBtn.addEventListener('click', async () => {
+    const email = el.emailInput.value.trim();
+    const password = el.passwordInput.value;
+    try {
+      if (runtime.isLoginMode) {
+        await signInWithEmailAndPassword(auth, email, password);
+      } else {
+        await createUserWithEmailAndPassword(auth, email, password);
+      }
+    } catch (err) {
+      el.loginError.textContent = err.message;
+    }
+  });
+
+  el.logoutBtn.addEventListener('click', () => signOut(auth));
+
+  onAuthStateChanged(auth, (user) => {
+    if (user) {
+      runtime.userId = user.uid;
+      el.userEmail.textContent = user.email;
+      el.loginView.classList.add('hidden');
+      el.mainContent.classList.remove('hidden');
+    } else {
+      runtime.userId = null;
+      el.userEmail.textContent = '';
+      el.mainContent.classList.add('hidden');
+      el.loginView.classList.remove('hidden');
+    }
+  });
+
+  updateMode();
 }
 
 export function isAuthenticated(user) {

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -3,3 +3,7 @@ import { isAuthenticated } from '../js/auth.js';
 test('isAuthenticated returns true for user object', () => {
   expect(isAuthenticated({})).toBe(true);
 });
+
+test('isAuthenticated returns false for null', () => {
+  expect(isAuthenticated(null)).toBe(false);
+});

--- a/tests/menu.test.js
+++ b/tests/menu.test.js
@@ -1,0 +1,67 @@
+import { jest } from '@jest/globals';
+
+test('history button shows history view and back returns to menu', async () => {
+  const createEl = (visible = false) => ({
+    classList: {
+      classes: new Set(visible ? [] : ['hidden']),
+      add(c) { this.classes.add(c); },
+      remove(c) { this.classes.delete(c); },
+      contains(c) { return this.classes.has(c); }
+    }
+  });
+
+  const mainMenu = createEl(true);
+  const history = createEl(false);
+  const setup = createEl(false);
+  const setupOrder = createEl(false);
+  const consumptionSetup = createEl(false);
+  const manageItems = createEl(false);
+
+  let historyClick;
+  let backClick;
+  const dummyBtn = () => ({ addEventListener: () => {} });
+
+  const el = {
+    mainMenu,
+    history,
+    setup,
+    setupOrder,
+    consumptionSetup,
+    manageItems,
+    startNewInventoryBtn: dummyBtn(),
+    continueInventoryBtn: dummyBtn(),
+    makeOrderBtn: dummyBtn(),
+    continueOrderBtn: dummyBtn(),
+    consumptionReportBtn: dummyBtn(),
+    historyBtn: { addEventListener: (_, cb) => { historyClick = cb; } },
+    manageItemsBtn: dummyBtn(),
+    backToMenuFromHistoryBtn: { addEventListener: (_, cb) => { backClick = cb; } },
+    backToMenuFromManageBtn: dummyBtn(),
+    backToMenuFromSelectInvBtn: dummyBtn(),
+    backToMenuFromConsumptionBtn: dummyBtn(),
+  };
+
+  const allViews = [mainMenu, history, setup, setupOrder, consumptionSetup, manageItems];
+
+  jest.unstable_mockModule('../js/elements.js', () => ({
+    getDOM: () => ({ el, allViews })
+  }));
+
+  global.document = {
+    addEventListener: () => {},
+    getElementById: () => ({ textContent: '' })
+  };
+
+  const { setupMenu } = await import('../js/app.js');
+  setupMenu();
+
+  // Simulate clicking history button
+  historyClick();
+  expect(mainMenu.classList.contains('hidden')).toBe(true);
+  expect(history.classList.contains('hidden')).toBe(false);
+
+  // Simulate clicking back to menu
+  backClick();
+  expect(mainMenu.classList.contains('hidden')).toBe(false);
+  expect(history.classList.contains('hidden')).toBe(true);
+});


### PR DESCRIPTION
## Summary
- Wire up email/password login and registration using Firebase
- Show/hide views and handle logout on auth state changes
- Add test case for unauthenticated users

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d0a9d4090832da5ce5d1b8726b6b2