### PR TITLE
fix: robust navigation and history

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,7 +1,7 @@
 import { initAuth } from './auth.js';
 import { initInventory } from './inventory.js';
 import { initOrders } from './orders.js';
-import { initHistory } from './history.js';
+import { initHistory, renderHistory } from './history.js';
 import { APP_VERSION } from './version.js';
 import { getDOM } from './elements.js';
 
@@ -18,18 +18,21 @@ export function setupMenu() {
     view.classList.remove('hidden');
   };
 
-  el.startNewInventoryBtn.addEventListener('click', () => show(el.setup));
-  el.continueInventoryBtn.addEventListener('click', () => show(el.setup));
-  el.makeOrderBtn.addEventListener('click', () => show(el.setupOrder));
-  el.continueOrderBtn.addEventListener('click', () => show(el.setupOrder));
-  el.consumptionReportBtn.addEventListener('click', () => show(el.consumptionSetup));
-  el.historyBtn.addEventListener('click', () => show(el.history));
-  el.manageItemsBtn.addEventListener('click', () => show(el.manageItems));
+  el.startNewInventoryBtn?.addEventListener('click', () => show(el.setup));
+  el.continueInventoryBtn?.addEventListener('click', () => show(el.setup));
+  el.makeOrderBtn?.addEventListener('click', () => show(el.setupOrder));
+  el.continueOrderBtn?.addEventListener('click', () => show(el.setupOrder));
+  el.consumptionReportBtn?.addEventListener('click', () => show(el.consumptionSetup));
+  el.historyBtn?.addEventListener('click', () => {
+    renderHistory();
+    show(el.history);
+  });
+  el.manageItemsBtn?.addEventListener('click', () => show(el.manageItems));
 
-  el.backToMenuFromHistoryBtn.addEventListener('click', () => show(el.mainMenu));
-  el.backToMenuFromManageBtn.addEventListener('click', () => show(el.mainMenu));
-  el.backToMenuFromSelectInvBtn.addEventListener('click', () => show(el.mainMenu));
-  el.backToMenuFromConsumptionBtn.addEventListener('click', () => show(el.mainMenu));
+  el.backToMenuFromHistoryBtn?.addEventListener('click', () => show(el.mainMenu));
+  el.backToMenuFromManageBtn?.addEventListener('click', () => show(el.mainMenu));
+  el.backToMenuFromSelectInvBtn?.addEventListener('click', () => show(el.mainMenu));
+  el.backToMenuFromConsumptionBtn?.addEventListener('click', () => show(el.mainMenu));
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/js/auth.js
+++ b/js/auth.js
@@ -26,14 +26,18 @@ export async function initAuth() {
     el.loginError.textContent = '';
   };
 
-  el.authToggleBtn.addEventListener('click', () => {
+  el.authToggleBtn?.addEventListener('click', () => {
     runtime.isLoginMode = !runtime.isLoginMode;
     updateMode();
   });
 
-  el.authActionBtn.addEventListener('click', async () => {
-    const email = el.emailInput.value.trim();
-    const password = el.passwordInput.value;
+  el.authActionBtn?.addEventListener('click', async () => {
+    const email = el.emailInput?.value.trim();
+    const password = el.passwordInput?.value;
+    if (!email || !password) {
+      el.loginError.textContent = 'Completa todos los campos';
+      return;
+    }
     try {
       if (runtime.isLoginMode) {
         await signInWithEmailAndPassword(auth, email, password);
@@ -45,19 +49,19 @@ export async function initAuth() {
     }
   });
 
-  el.logoutBtn.addEventListener('click', () => signOut(auth));
+  el.logoutBtn?.addEventListener('click', () => signOut(auth));
 
   onAuthStateChanged(auth, (user) => {
     if (user) {
       runtime.userId = user.uid;
-      el.userEmail.textContent = user.email;
-      el.loginView.classList.add('hidden');
-      el.mainContent.classList.remove('hidden');
+      if (el.userEmail) el.userEmail.textContent = user.email;
+      el.loginView?.classList.add('hidden');
+      el.mainContent?.classList.remove('hidden');
     } else {
       runtime.userId = null;
-      el.userEmail.textContent = '';
-      el.mainContent.classList.add('hidden');
-      el.loginView.classList.remove('hidden');
+      if (el.userEmail) el.userEmail.textContent = '';
+      el.mainContent?.classList.add('hidden');
+      el.loginView?.classList.remove('hidden');
     }
   });
 

--- a/js/history.js
+++ b/js/history.js
@@ -1,7 +1,50 @@
-export function initHistory() {
-  console.log('History initialized');
+let renderFn;
+
+export async function initHistory() {
+  const { state } = await import('./state.js');
+  const { getDOM } = await import('./elements.js');
+
+  try {
+    const stored = localStorage.getItem('history');
+    state.history = stored ? JSON.parse(stored) : [];
+  } catch {
+    state.history = [];
+  }
+
+  const render = () => {
+    const { el } = getDOM();
+    if (!el?.historyList) return;
+    el.historyList.innerHTML = '';
+    if (state.history.length === 0) {
+      const empty = document.createElement('div');
+      empty.textContent = 'Sin historial disponible';
+      el.historyList.appendChild(empty);
+      return;
+    }
+    state.history.forEach(entry => {
+      const item = document.createElement('div');
+      item.textContent = entry?.title || entry?.date || 'Historial';
+      el.historyList.appendChild(item);
+    });
+  };
+
+  renderFn = render;
+  renderFn();
+}
+
+export function renderHistory() {
+  if (typeof renderFn === 'function') {
+    renderFn();
+  }
 }
 
 export function historyCount(entries = []) {
   return entries.length;
+}
+
+export async function addHistoryEntry(entry) {
+  const { state } = await import('./state.js');
+  state.history.push(entry);
+  localStorage.setItem('history', JSON.stringify(state.history));
+  renderHistory();
 }

--- a/tests/history.test.js
+++ b/tests/history.test.js
@@ -1,5 +1,40 @@
-import { historyCount } from '../js/history.js';
+import { historyCount, addHistoryEntry, initHistory, renderHistory } from '../js/history.js';
+
+beforeEach(() => {
+  global.localStorage = {
+    store: {},
+    getItem(key) { return this.store[key]; },
+    setItem(key, val) { this.store[key] = String(val); }
+  };
+  global.document = {
+    getElementById: (id) => (id === 'history-list' ? { innerHTML: '', appendChild: () => {} } : null),
+    querySelectorAll: () => [],
+    createElement: () => ({ textContent: '', appendChild: () => {} })
+  };
+});
 
 test('historyCount returns number of entries', () => {
   expect(historyCount([1,2,3])).toBe(3);
+});
+
+test('addHistoryEntry stores data in state and localStorage', async () => {
+  const { state } = await import('../js/state.js');
+  state.history = [];
+  await initHistory();
+  await addHistoryEntry({ title: 'Pedido 1' });
+  expect(state.history).toHaveLength(1);
+  expect(JSON.parse(global.localStorage.getItem('history'))).toHaveLength(1);
+});
+
+test('renderHistory outputs entries to DOM', async () => {
+  const list = { innerHTML: '', appendChild: () => { list.innerHTML += 'x'; } };
+  global.document = {
+    getElementById: (id) => (id === 'history-list' ? list : null),
+    querySelectorAll: () => [],
+    createElement: () => ({ textContent: '', appendChild: () => {} })
+  };
+  global.localStorage.setItem('history', JSON.stringify([{ title: 'Pedido 1' }]));
+  await initHistory();
+  renderHistory();
+  expect(list.innerHTML).not.toBe('');
 });

--- a/tests/menu.test.js
+++ b/tests/menu.test.js
@@ -46,6 +46,11 @@ test('history button shows history view and back returns to menu', async () => {
   jest.unstable_mockModule('../js/elements.js', () => ({
     getDOM: () => ({ el, allViews })
   }));
+  const renderHistory = jest.fn();
+  jest.unstable_mockModule('../js/history.js', () => ({
+    renderHistory,
+    initHistory: jest.fn()
+  }));
 
   global.document = {
     addEventListener: () => {},
@@ -57,6 +62,7 @@ test('history button shows history view and back returns to menu', async () => {
 
   // Simulate clicking history button
   historyClick();
+  expect(renderHistory).toHaveBeenCalled();
   expect(mainMenu.classList.contains('hidden')).toBe(true);
   expect(history.classList.contains('hidden')).toBe(false);
 


### PR DESCRIPTION
## Summary
- render history entries on demand with fallback when empty and auto-update after additions
- guard navigation and auth setup against missing DOM elements and validate credentials
- test history rendering and menu navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d1525efd4832dadf6db97dcc2bb2c