### PR TITLE
feat: enable inventory and order flows

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,15 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
+    <script type="importmap">
+    {
+        "imports": {
+            "firebase/app": "https://www.gstatic.com/firebasejs/12.1.0/firebase-app.js",
+            "firebase/auth": "https://www.gstatic.com/firebasejs/12.1.0/firebase-auth.js",
+            "firebase/firestore": "https://www.gstatic.com/firebasejs/12.1.0/firebase-firestore.js"
+        }
+    }
+    </script>
 </head>
 <body class="bg-gray-900 text-white min-h-screen flex flex-col items-center justify-center p-4">
 

--- a/js/app.js
+++ b/js/app.js
@@ -1,14 +1,21 @@
 import { initAuth } from './auth.js';
 import { initInventory } from './inventory.js';
 import { initOrders } from './orders.js';
-import { initHistory } from './history.js';
+import { initHistory, renderHistory } from './history.js';
 import { APP_VERSION } from './version.js';
 import { getDOM } from './elements.js';
+import { state } from './state.js';
 
 export function initApp() {
   const { el } = getDOM();
   el.loadingView.classList.add('hidden');
   el.loginView.classList.remove('hidden');
+}
+
+export function updateMenuButtons() {
+  const { el } = getDOM();
+  el.continueInventoryBtn?.classList.toggle('hidden', !state.currentInventory);
+  el.continueOrderBtn?.classList.toggle('hidden', !state.currentOrder);
 }
 
 export function setupMenu() {
@@ -18,18 +25,23 @@ export function setupMenu() {
     view.classList.remove('hidden');
   };
 
-  el.startNewInventoryBtn.addEventListener('click', () => show(el.setup));
-  el.continueInventoryBtn.addEventListener('click', () => show(el.setup));
-  el.makeOrderBtn.addEventListener('click', () => show(el.setupOrder));
-  el.continueOrderBtn.addEventListener('click', () => show(el.setupOrder));
-  el.consumptionReportBtn.addEventListener('click', () => show(el.consumptionSetup));
-  el.historyBtn.addEventListener('click', () => show(el.history));
-  el.manageItemsBtn.addEventListener('click', () => show(el.manageItems));
+  updateMenuButtons();
 
-  el.backToMenuFromHistoryBtn.addEventListener('click', () => show(el.mainMenu));
-  el.backToMenuFromManageBtn.addEventListener('click', () => show(el.mainMenu));
-  el.backToMenuFromSelectInvBtn.addEventListener('click', () => show(el.mainMenu));
-  el.backToMenuFromConsumptionBtn.addEventListener('click', () => show(el.mainMenu));
+  el.startNewInventoryBtn?.addEventListener('click', () => show(el.setup));
+  el.continueInventoryBtn?.addEventListener('click', () => show(el.setup));
+  el.makeOrderBtn?.addEventListener('click', () => show(el.setupOrder));
+  el.continueOrderBtn?.addEventListener('click', () => show(el.setupOrder));
+  el.consumptionReportBtn?.addEventListener('click', () => show(el.consumptionSetup));
+  el.historyBtn?.addEventListener('click', () => {
+    renderHistory();
+    show(el.history);
+  });
+  el.manageItemsBtn?.addEventListener('click', () => show(el.manageItems));
+
+  el.backToMenuFromHistoryBtn?.addEventListener('click', () => { show(el.mainMenu); updateMenuButtons(); });
+  el.backToMenuFromManageBtn?.addEventListener('click', () => { show(el.mainMenu); updateMenuButtons(); });
+  el.backToMenuFromSelectInvBtn?.addEventListener('click', () => { show(el.mainMenu); updateMenuButtons(); });
+  el.backToMenuFromConsumptionBtn?.addEventListener('click', () => { show(el.mainMenu); updateMenuButtons(); });
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/js/auth.js
+++ b/js/auth.js
@@ -1,14 +1,9 @@
-export async function initAuth() {
-  const { getDOM } = await import('./elements.js');
-  const {
-    auth,
-    signInWithEmailAndPassword,
-    createUserWithEmailAndPassword,
-    signOut,
-    onAuthStateChanged,
-  } = await import('./firebase.js');
-  const { runtime } = await import('./state.js');
+import { getDOM } from './elements.js';
+import { auth, signInWithEmailAndPassword, createUserWithEmailAndPassword, signOut, onAuthStateChanged } from './firebase.js';
+import { runtime } from './state.js';
+import { initializeMasterItems, initManageItems } from './items.js';
 
+export function initAuth() {
   const { el } = getDOM();
 
   const updateMode = () => {
@@ -51,9 +46,12 @@ export async function initAuth() {
 
   el.logoutBtn?.addEventListener('click', () => signOut(auth));
 
-  onAuthStateChanged(auth, (user) => {
+  onAuthStateChanged(auth, async (user) => {
     if (user) {
       runtime.userId = user.uid;
+      await initializeMasterItems(user.uid);
+      initManageItems();
+
       if (el.userEmail) el.userEmail.textContent = user.email;
       el.loginView?.classList.add('hidden');
       el.mainContent?.classList.remove('hidden');

--- a/js/auth.js
+++ b/js/auth.js
@@ -26,14 +26,18 @@ export async function initAuth() {
     el.loginError.textContent = '';
   };
 
-  el.authToggleBtn.addEventListener('click', () => {
+  el.authToggleBtn?.addEventListener('click', () => {
     runtime.isLoginMode = !runtime.isLoginMode;
     updateMode();
   });
 
-  el.authActionBtn.addEventListener('click', async () => {
-    const email = el.emailInput.value.trim();
-    const password = el.passwordInput.value;
+  el.authActionBtn?.addEventListener('click', async () => {
+    const email = el.emailInput?.value.trim();
+    const password = el.passwordInput?.value;
+    if (!email || !password) {
+      el.loginError.textContent = 'Completa todos los campos';
+      return;
+    }
     try {
       if (runtime.isLoginMode) {
         await signInWithEmailAndPassword(auth, email, password);
@@ -45,19 +49,19 @@ export async function initAuth() {
     }
   });
 
-  el.logoutBtn.addEventListener('click', () => signOut(auth));
+  el.logoutBtn?.addEventListener('click', () => signOut(auth));
 
   onAuthStateChanged(auth, (user) => {
     if (user) {
       runtime.userId = user.uid;
-      el.userEmail.textContent = user.email;
-      el.loginView.classList.add('hidden');
-      el.mainContent.classList.remove('hidden');
+      if (el.userEmail) el.userEmail.textContent = user.email;
+      el.loginView?.classList.add('hidden');
+      el.mainContent?.classList.remove('hidden');
     } else {
       runtime.userId = null;
-      el.userEmail.textContent = '';
-      el.mainContent.classList.add('hidden');
-      el.loginView.classList.remove('hidden');
+      if (el.userEmail) el.userEmail.textContent = '';
+      el.mainContent?.classList.add('hidden');
+      el.loginView?.classList.remove('hidden');
     }
   });
 

--- a/js/auth.js
+++ b/js/auth.js
@@ -3,6 +3,23 @@ import { auth, signInWithEmailAndPassword, createUserWithEmailAndPassword, signO
 import { runtime } from './state.js';
 import { initializeMasterItems, initManageItems } from './items.js';
 
+function getAuthErrorMessage(error) {
+  const code = error?.code || '';
+  const messages = {
+    'auth/invalid-email': 'El correo no tiene un formato valido.',
+    'auth/invalid-credential': 'El correo o la contrasena no son correctos.',
+    'auth/user-not-found': 'No existe una cuenta con ese correo.',
+    'auth/wrong-password': 'La contrasena no es correcta.',
+    'auth/email-already-in-use': 'Ya existe una cuenta con ese correo.',
+    'auth/weak-password': 'La contrasena debe tener al menos 6 caracteres.',
+    'auth/too-many-requests': 'Demasiados intentos. Espera un momento y volve a probar.',
+    'auth/network-request-failed': 'No se pudo conectar con Firebase. Revisa la conexion.',
+    'auth/unauthorized-domain': 'Este dominio no esta autorizado en Firebase Auth.'
+  };
+
+  return messages[code] || 'No se pudo ingresar. Revisa los datos e intenta de nuevo.';
+}
+
 export function initAuth() {
   const { el } = getDOM();
 
@@ -33,6 +50,9 @@ export function initAuth() {
       el.loginError.textContent = 'Completa todos los campos';
       return;
     }
+    el.loginError.textContent = '';
+    el.authActionBtn.disabled = true;
+    el.authActionBtn.textContent = runtime.isLoginMode ? 'Ingresando...' : 'Creando cuenta...';
     try {
       if (runtime.isLoginMode) {
         await signInWithEmailAndPassword(auth, email, password);
@@ -40,7 +60,10 @@ export function initAuth() {
         await createUserWithEmailAndPassword(auth, email, password);
       }
     } catch (err) {
-      el.loginError.textContent = err.message;
+      el.loginError.textContent = getAuthErrorMessage(err);
+    } finally {
+      el.authActionBtn.disabled = false;
+      el.authActionBtn.textContent = runtime.isLoginMode ? 'Iniciar SesiÃ³n' : 'Crear Cuenta';
     }
   });
 

--- a/js/firebase.js
+++ b/js/firebase.js
@@ -44,6 +44,7 @@ export const getRefs = (userId) => ({
 });
 
 export {
+  getRefs,
   signInWithPopup,
   GoogleAuthProvider,
   signOut,

--- a/js/firebase.js
+++ b/js/firebase.js
@@ -1,4 +1,4 @@
-import { initializeApp } from "https://www.gstatic.com/firebasejs/9.15.0/firebase-app.js";
+import { initializeApp } from "firebase/app";
 import {
   getAuth,
   signInWithPopup,
@@ -7,7 +7,7 @@ import {
   onAuthStateChanged,
   createUserWithEmailAndPassword,
   signInWithEmailAndPassword
-} from "https://www.gstatic.com/firebasejs/9.15.0/firebase-auth.js";
+} from "firebase/auth";
 import {
   getFirestore,
   doc,
@@ -20,7 +20,7 @@ import {
   query,
   orderBy,
   deleteDoc
-} from "https://www.gstatic.com/firebasejs/9.15.0/firebase-firestore.js";
+} from "firebase/firestore";
 
 const firebaseConfig = {
   apiKey: "AIzaSyB7MrPbY7cwywvOnyz_-5RXFO1S40Z6Ous",
@@ -35,7 +35,7 @@ const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const db = getFirestore(app);
 
-export const getRefs = (userId) => ({
+const getRefs = (userId) => ({
   masterItems: () => doc(db, 'users', userId, 'data', 'masterItems'),
   currentInventory: () => doc(db, 'users', userId, 'data', 'currentInventory'),
   currentOrder: () => doc(db, 'users', userId, 'data', 'currentOrder'),

--- a/js/history.js
+++ b/js/history.js
@@ -1,9 +1,9 @@
+import { state } from './state.js';
+import { getDOM } from './elements.js';
+
 let renderFn;
 
-export async function initHistory() {
-  const { state } = await import('./state.js');
-  const { getDOM } = await import('./elements.js');
-
+export function initHistory() {
   try {
     const stored = localStorage.getItem('history');
     state.history = stored ? JSON.parse(stored) : [];
@@ -42,8 +42,7 @@ export function historyCount(entries = []) {
   return entries.length;
 }
 
-export async function addHistoryEntry(entry) {
-  const { state } = await import('./state.js');
+export function addHistoryEntry(entry) {
   state.history.push(entry);
   localStorage.setItem('history', JSON.stringify(state.history));
   renderHistory();

--- a/js/history.js
+++ b/js/history.js
@@ -1,7 +1,50 @@
-export function initHistory() {
-  console.log('History initialized');
+let renderFn;
+
+export async function initHistory() {
+  const { state } = await import('./state.js');
+  const { getDOM } = await import('./elements.js');
+
+  try {
+    const stored = localStorage.getItem('history');
+    state.history = stored ? JSON.parse(stored) : [];
+  } catch {
+    state.history = [];
+  }
+
+  const render = () => {
+    const { el } = getDOM();
+    if (!el?.historyList) return;
+    el.historyList.innerHTML = '';
+    if (state.history.length === 0) {
+      const empty = document.createElement('div');
+      empty.textContent = 'Sin historial disponible';
+      el.historyList.appendChild(empty);
+      return;
+    }
+    state.history.forEach(entry => {
+      const item = document.createElement('div');
+      item.textContent = entry?.title || entry?.date || 'Historial';
+      el.historyList.appendChild(item);
+    });
+  };
+
+  renderFn = render;
+  renderFn();
+}
+
+export function renderHistory() {
+  if (typeof renderFn === 'function') {
+    renderFn();
+  }
 }
 
 export function historyCount(entries = []) {
   return entries.length;
+}
+
+export async function addHistoryEntry(entry) {
+  const { state } = await import('./state.js');
+  state.history.push(entry);
+  localStorage.setItem('history', JSON.stringify(state.history));
+  renderHistory();
 }

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1,16 +1,74 @@
-export async function initInventory() {
-  const { getDOM } = await import('./elements.js');
-  const { state } = await import('./state.js');
-  const { updateMenuButtons } = await import('./app.js');
+import { getDOM } from './elements.js';
+import { state, runtime } from './state.js';
+import { updateMenuButtons } from './app.js';
 
+function displayCurrentItem() {
+  const { el } = getDOM();
+  const item = runtime.itemsToCountQueue[runtime.positionInQueue];
+  el.itemName.textContent = item.name;
+  el.itemCounter.textContent = `${runtime.positionInQueue + 1}/${runtime.itemsToCountQueue.length}`;
+  const existingItem = state.currentInventory.items.find(i => i.id === item.id);
+  el.itemQuantity.value = existingItem ? existingItem.quantity : '';
+}
+
+function nextItem() {
+  const { el } = getDOM();
+  const item = runtime.itemsToCountQueue[runtime.positionInQueue];
+  const quantity = parseFloat(el.itemQuantity.value);
+
+  if (!isNaN(quantity)) {
+    const existingItemIndex = state.currentInventory.items.findIndex(i => i.id === item.id);
+    if (existingItemIndex > -1) {
+      state.currentInventory.items[existingItemIndex].quantity = quantity;
+    } else {
+      state.currentInventory.items.push({ id: item.id, name: item.name, quantity });
+    }
+  }
+
+  runtime.positionInQueue++;
+  if (runtime.positionInQueue < runtime.itemsToCountQueue.length) {
+    displayCurrentItem();
+  } else {
+    el.item.classList.add('hidden');
+    el.summary.classList.remove('hidden');
+  }
+}
+
+export function initInventory() {
   const { el } = getDOM();
 
   el.startCountingBtn?.addEventListener('click', () => {
     state.currentInventory = { startedAt: Date.now(), items: [] };
+    runtime.itemsToCountQueue = [...state.masterItems];
+    runtime.positionInQueue = 0;
+    displayCurrentItem();
     el.setup?.classList.add('hidden');
     el.item?.classList.remove('hidden');
     el.continueInventoryBtn?.classList.remove('hidden');
     updateMenuButtons();
+  });
+
+  el.nextBtn?.addEventListener('click', nextItem);
+
+  el.skipBtn?.addEventListener('click', () => {
+    runtime.positionInQueue++;
+    if (runtime.positionInQueue < runtime.itemsToCountQueue.length) {
+      displayCurrentItem();
+    } else {
+      el.item.classList.add('hidden');
+      el.summary.classList.remove('hidden');
+    }
+  });
+
+  el.naBtn?.addEventListener('click', () => {
+    const item = runtime.itemsToCountQueue[runtime.positionInQueue];
+    const existingItemIndex = state.currentInventory.items.findIndex(i => i.id === item.id);
+    if (existingItemIndex > -1) {
+      state.currentInventory.items[existingItemIndex].quantity = 'N/A';
+    } else {
+      state.currentInventory.items.push({ id: item.id, name: item.name, quantity: 'N/A' });
+    }
+    nextItem();
   });
 }
 

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1,5 +1,17 @@
-export function initInventory() {
-  console.log('Inventory initialized');
+export async function initInventory() {
+  const { getDOM } = await import('./elements.js');
+  const { state } = await import('./state.js');
+  const { updateMenuButtons } = await import('./app.js');
+
+  const { el } = getDOM();
+
+  el.startCountingBtn?.addEventListener('click', () => {
+    state.currentInventory = { startedAt: Date.now(), items: [] };
+    el.setup?.classList.add('hidden');
+    el.item?.classList.remove('hidden');
+    el.continueInventoryBtn?.classList.remove('hidden');
+    updateMenuButtons();
+  });
 }
 
 export function calculateInventoryValue(items = []) {

--- a/js/items.js
+++ b/js/items.js
@@ -1,1 +1,108 @@
-export const initialItemsList = ["ACEITE FRITURA", "ALMIBAR PARA FACTURA X 7 KG", "AZUCAR INDIVIDUAL KFC", "BANDEJA CANOA KFC", "BOLSA DE LLEVAR GRANDE KFC2", "BOLSA DE RESIDUOS CHICA", "BOLSA DE RESIDUOS NEGRA X 250 UND", "BOLSA DE RESIDUOS TRANSPARENTE", "BOLSA PARA MARINADO K EN ROLLOS", "BOLSA SIN MANIJA GRANDE KFC X 250 UND", "BUCKET 130OZ KFC X 300UN", "BUCKET 50OZ X 420 UND", "BUCKET 85OZ X 330 UND", "CAFE EN POLVO", "CAJA BIG BOXKFC", "CAJA SNACK CON TAPA KFC X 800 UND", "CANDADITOS KFC", "CHOCOLATE CON MANI X 4.32KG", "CHOCOLATE EN POLVO X 4KG", "CINTA DE SEGURIDAD KFC X 36 UND", "COFIA DE FISELINA DESCARTABLE", "CONO HELADO", "CUCHARITA PARA HELADO X 1000 UND", "CUCHILLO", "EDULCORANTE INDIVIDUAL KFC", "ESTUCHE PAPA CHICA KFC X 800 UND", "ESTUCHE PAPAS GRANDES KFC", "ESTUCHE PAPAS MEDIANAS KFC", "ESTUCHE POPCORN GRANDE", "ESTUCHE POPCORN MEDIANO", "ETC TEMPERO", "FILTRO FREIDORAS FRYMASTER", "FILTRO FREIDORAS HENNY PENNY", "GALLETITA OREO CAJA X36 X 117 GR", "GUANTES VINILO M", "HARINA X 11.389KG", "JUGO DE LIMON INDIVIDUAL", "KETCHUP INDIVIDUAL", "LAMINA ANTIGRASA SANDWICH KFC X1500", "LECHE EN POLVO CAJAX10KG", "MANTECOL", "MANTELITO KFC", "MAYONESA INDIVIDUAL", "MEZCLA HUEVO/LECHE", "MOSTAZA CON MIEL", "MOSTAZA CON MIEL INDIVIDUAL", "MOSTAZA INDIVIDUAL", "PAÑO BLANCO X 300 UN", "PAÑO AZUL", "PAÑO ROJO", "PAPEL ANTIGRASA BLANCO", "PAPEL ANTIGRASA GENERICO CAJA X 4000", "PAPEL ANTIGRASA SANDWICH KFC 2", "PAPEL DE MANOS (TO)", "PAPEL FILM (ROLLO)", "PAPEL HIGIENICO", "PAPEL SILICONADO X 500 UND", "PORTAVASOS KFC X 200 UND", "REVOLVEDOR CAFE MADERA", "ROLLO IMPRESORA FISCAL GENERICO 2", "SAL A GRANEL", "SAL SOBRE INDIVIDUAL KFC", "SALSA BARBACOA A GRANEL", "SALSA BARBACOA INDIVIDUAL", "SALSA PICANTE A GRANEL", "SALSA PICANTE INDIVIDUAL", "SEASONING OR", "SERVILLETAS 30X30 X 5000 UND", "SERVILletas PARA CONO", "SOBRE KFC X 1000 UND", "STICKER REDONDO AMARILLO", "STICKER REDONDO AZUL", "STICKER REDONDO NARANJA", "STICKER REDONDO NEGRO", "STICKER REDONDO ROJO", "STICKER REDONDO VERDE", "STICKER VENCIMIENTO", "SUNDAE KFC 7.25 OZ X 2000 UND", "TAPA BUCKET KFC X 2150 UND", "TAPA CAJA BIG BOX", "TAPA DIPPER", "TAPA VASO CAFE 8 Y 12 OZ X 2000 UND", "TAPA VASO GASEOSA 16OZ", "TAPA VASO GASEOSA 12OZ", "TE INTIZEN ILUMINE (ROJO)", "TENEDOR", "QUESO CHEDDAR EN POLVO", "VASO AVALANCHA KFC X 1200 UND", "VASO CAFE 8 OZ KFC", "VASO CORTESIA KFC", "VASO GASEOSA 12OZ KFC A", "VASO GASEOSA 16OZ KFC A", "VASO GASEOSA 21OZ KFC", "VASO CAFE 12 OZ KFC X 1000", "HELADO DULCE DE LECHE", "HELADO VAINILLA", "JARABE DE FRUTILLA", "SALSA DE CHOCOLATE", "SALSA DE DULCE DE LECHE X 5KG", "QUESO CHEDDAR EN FETAS 2", "LOMITO EN FETAS", "PANCETA KFC", "MANTECA X 6KG", "MAYONESA A GRANEL", "MIXDE ENSALADA", "TOMATE", "PAN PORTENO", "PANAL MEMBRILLO X 72 UND", "REJILLA PASTELERA X 72 UND", "MEDIALUNA DE GRASA X 240 UND", "MEDIALUNA DE MANTECA X 180 UND", "HELADO CONG SUNDAE CHOC", "HELADO CONGELADO SUNDAE DDL", "HELADO CONGELADO AVALANCHA KFC", "PAPAS FRITAS KFC C7 X 18 KG", "AROS DE CEBOLLA X 10KG"];
+import { db, getRefs, setDoc, getDoc, onSnapshot, updateDoc } from './firebase.js';
+import { state, runtime } from './state.js';
+import { getDOM } from './elements.js';
+
+const initialItemsList = ["ACEITE FRITURA", "ALMIBAR PARA FACTURA X 7 KG", "AZUCAR INDIVIDUAL KFC", "BANDEJA CANOA KFC", "BOLSA DE LLEVAR GRANDE KFC2", "BOLSA DE RESIDUOS CHICA", "BOLSA DE RESIDUOS NEGRA X 250 UND", "BOLSA DE RESIDUOS TRANSPARENTE", "BOLSA PARA MARINADO K EN ROLLOS", "BOLSA SIN MANIJA GRANDE KFC X 250 UND", "BUCKET 130OZ KFC X 300UN", "BUCKET 50OZ X 420 UND", "BUCKET 85OZ X 330 UND", "CAFE EN POLVO", "CAJA BIG BOXKFC", "CAJA SNACK CON TAPA KFC X 800 UND", "CANDADITOS KFC", "CHOCOLATE CON MANI X 4.32KG", "CHOCOLATE EN POLVO X 4KG", "CINTA DE SEGURIDAD KFC X 36 UND", "COFIA DE FISELINA DESCARTABLE", "CONO HELADO", "CUCHARITA PARA HELADO X 1000 UND", "CUCHILLO", "EDULCORANTE INDIVIDUAL KFC", "ESTUCHE PAPA CHICA KFC X 800 UND", "ESTUCHE PAPAS GRANDES KFC", "ESTUCHE PAPAS MEDIANAS KFC", "ESTUCHE POPCORN GRANDE", "ESTUCHE POPCORN MEDIANO", "ETC TEMPERO", "FILTRO FREIDORAS FRYMASTER", "FILTRO FREIDORAS HENNY PENNY", "GALLETITA OREO CAJA X36 X 117 GR", "GUANTES VINILO M", "HARINA X 11.389KG", "JUGO DE LIMON INDIVIDUAL", "KETCHUP INDIVIDUAL", "LAMINA ANTIGRASA SANDWICH KFC X1500", "LECHE EN POLVO CAJAX10KG", "MANTECOL", "MANTELITO KFC", "MAYONESA INDIVIDUAL", "MEZCLA HUEVO/LECHE", "MOSTAZA CON MIEL", "MOSTAZA CON MIEL INDIVIDUAL", "MOSTAZA INDIVIDUAL", "PAÑO BLANCO X 300 UN", "PAÑO AZUL", "PAÑO ROJO", "PAPEL ANTIGRASA BLANCO", "PAPEL ANTIGRASA GENERICO CAJA X 4000", "PAPEL ANTIGRASA SANDWICH KFC 2", "PAPEL DE MANOS (TO)", "PAPEL FILM (ROLLO)", "PAPEL HIGIENICO", "PAPEL SILICONADO X 500 UND", "PORTAVASOS KFC X 200 UND", "REVOLVEDOR CAFE MADERA", "ROLLO IMPRESORA FISCAL GENERICO 2", "SAL A GRANEL", "SAL SOBRE INDIVIDUAL KFC", "SALSA BARBACOA A GRANEL", "SALSA BARBACOA INDIVIDUAL", "SALSA PICANTE A GRANEL", "SALSA PICANTE INDIVIDUAL", "SEASONING OR", "SERVILLETAS 30X30 X 5000 UND", "SERVILletas PARA CONO", "SOBRE KFC X 1000 UND", "STICKER REDONDO AMARILLO", "STICKER REDONDO AZUL", "STICKER REDONDO NARANJA", "STICKER REDONDO NEGRO", "STICKER REDONDO ROJO", "STICKER REDONDO VERDE", "STICKER VENCIMIENTO", "SUNDAE KFC 7.25 OZ X 2000 UND", "TAPA BUCKET KFC X 2150 UND", "TAPA CAJA BIG BOX", "TAPA DIPPER", "TAPA VASO CAFE 8 Y 12 OZ X 2000 UND", "TAPA VASO GASEOSA 16OZ", "TAPA VASO GASEOSA 12OZ", "TE INTIZEN ILUMINE (ROJO)", "TENEDOR", "QUESO CHEDDAR EN POLVO", "VASO AVALANCHA KFC X 1200 UND", "VASO CAFE 8 OZ KFC", "VASO CORTESIA KFC", "VASO GASEOSA 12OZ KFC A", "VASO GASEOSA 16OZ KFC A", "VASO GASEOSA 21OZ KFC", "VASO CAFE 12 OZ KFC X 1000", "HELADO DULCE DE LECHE", "HELADO VAINILLA", "JARABE DE FRUTILLA", "SALSA DE CHOCOLATE", "SALSA DE DULCE DE LECHE X 5KG", "QUESO CHEDDAR EN FETAS 2", "LOMITO EN FETAS", "PANCETA KFC", "MANTECA X 6KG", "MAYONESA A GRANEL", "MIXDE ENSALADA", "TOMATE", "PAN PORTENO", "PANAL MEMBRILLO X 72 UND", "REJILLA PASTELERA X 72 UND", "MEDIALUNA DE GRASA X 240 UND", "MEDIALUNA DE MANTECA X 180 UND", "HELADO CONG SUNDAE CHOC", "HELADO CONGELADO SUNDAE DDL", "HELADO CONGELADO AVALANCHA KFC", "PAPAS FRITAS KFC C7 X 18 KG", "AROS DE CEBOLLA X 10KG"];
+
+export async function initializeMasterItems(userId) {
+  const refs = getRefs(userId);
+  const masterItemsRef = refs.masterItems();
+  const docSnap = await getDoc(masterItemsRef);
+
+  if (!docSnap.exists()) {
+    const items = initialItemsList.map((name, index) => ({
+      id: `${Date.now()}-${index}`,
+      name,
+      order: index
+    }));
+    await setDoc(masterItemsRef, { items });
+    state.masterItems = items;
+  }
+}
+
+function renderManageableItems() {
+  const { el } = getDOM();
+  if (!el.manageItemsList) return;
+  const items = state.masterItems.sort((a, b) => a.order - b.order);
+  el.manageItemsList.innerHTML = items.map((item, index) => `
+    <div class="flex items-center justify-between p-2 rounded-lg bg-gray-700" draggable="true" data-index="${index}">
+      <span class="text-white">${item.name}</span>
+      <div>
+        <button class="edit-item-btn p-1 text-blue-400 hover:text-blue-300" data-id="${item.id}">Editar</button>
+        <button class="delete-item-btn p-1 text-red-400 hover:text-red-300" data-id="${item.id}">Borrar</button>
+      </div>
+    </div>
+  `).join('');
+}
+
+export function initManageItems() {
+  const { el } = getDOM();
+
+  if (runtime.unsubscribe.masterItems) runtime.unsubscribe.masterItems();
+  const refs = getRefs(runtime.userId);
+  runtime.unsubscribe.masterItems = onSnapshot(refs.masterItems(), (doc) => {
+    state.masterItems = doc.data()?.items || [];
+    renderManageableItems();
+  });
+
+  el.addItemBtn.addEventListener('click', async () => {
+    const newItemName = el.newItemName.value.trim();
+    if (newItemName) {
+      const newItem = {
+        id: `${Date.now()}`,
+        name: newItemName,
+        order: state.masterItems.length
+      };
+      const updatedItems = [...state.masterItems, newItem];
+      await updateDoc(refs.masterItems(), { items: updatedItems });
+      el.newItemName.value = '';
+    }
+  });
+
+  el.manageItemsList.addEventListener('click', async (e) => {
+    const refs = getRefs(runtime.userId);
+    if (e.target.classList.contains('delete-item-btn')) {
+      const itemId = e.target.dataset.id;
+      const updatedItems = state.masterItems.filter(item => item.id !== itemId);
+      await updateDoc(refs.masterItems(), { items: updatedItems });
+    }
+
+    if (e.target.classList.contains('edit-item-btn')) {
+      const itemId = e.target.dataset.id;
+      const item = state.masterItems.find(item => item.id === itemId);
+      const newName = prompt('Enter new name', item.name);
+      if (newName) {
+        const updatedItems = state.masterItems.map(i => i.id === itemId ? { ...i, name: newName } : i);
+        await updateDoc(refs.masterItems(), { items: updatedItems });
+      }
+    }
+  });
+
+  el.manageItemsList.addEventListener('dragstart', (e) => {
+    runtime.draggedItemIndex = parseInt(e.target.dataset.index, 10);
+  });
+
+  el.manageItemsList.addEventListener('dragover', (e) => {
+    e.preventDefault();
+  });
+
+  el.manageItemsList.addEventListener('drop', (e) => {
+    e.preventDefault();
+    const droppedOnItem = e.target.closest('[data-index]');
+    if (droppedOnItem) {
+      const droppedOnIndex = parseInt(droppedOnItem.dataset.index, 10);
+      const draggedItem = state.masterItems[runtime.draggedItemIndex];
+      const items = [...state.masterItems];
+      items.splice(runtime.draggedItemIndex, 1);
+      items.splice(droppedOnIndex, 0, draggedItem);
+      state.masterItems = items.map((item, index) => ({ ...item, order: index }));
+      renderManageableItems();
+    }
+  });
+
+  el.saveItemOrderBtn.addEventListener('click', async () => {
+    const refs = getRefs(runtime.userId);
+    await updateDoc(refs.masterItems(), { items: state.masterItems });
+    alert('Order saved!');
+  });
+}

--- a/js/orders.js
+++ b/js/orders.js
@@ -1,5 +1,17 @@
-export function initOrders() {
-  console.log('Orders initialized');
+export async function initOrders() {
+  const { getDOM } = await import('./elements.js');
+  const { state } = await import('./state.js');
+  const { updateMenuButtons } = await import('./app.js');
+
+  const { el } = getDOM();
+
+  el.startOrderingBtn?.addEventListener('click', () => {
+    state.currentOrder = { startedAt: Date.now(), items: [] };
+    el.setupOrder?.classList.add('hidden');
+    el.orderItem?.classList.remove('hidden');
+    el.continueOrderBtn?.classList.remove('hidden');
+    updateMenuButtons();
+  });
 }
 
 export function pendingOrders(orders = []) {

--- a/js/orders.js
+++ b/js/orders.js
@@ -1,16 +1,74 @@
-export async function initOrders() {
-  const { getDOM } = await import('./elements.js');
-  const { state } = await import('./state.js');
-  const { updateMenuButtons } = await import('./app.js');
+import { getDOM } from './elements.js';
+import { state, runtime } from './state.js';
+import { updateMenuButtons } from './app.js';
 
+function displayCurrentOrderItem() {
+  const { el } = getDOM();
+  const item = runtime.itemsToCountQueue[runtime.positionInQueue];
+  el.orderItemName.textContent = item.name;
+  el.orderItemCounter.textContent = `${runtime.positionInQueue + 1}/${runtime.itemsToCountQueue.length}`;
+  const existingItem = state.currentOrder.items.find(i => i.id === item.id);
+  el.orderItemQuantity.value = existingItem ? existingItem.quantity : '';
+}
+
+function nextOrderItem() {
+  const { el } = getDOM();
+  const item = runtime.itemsToCountQueue[runtime.positionInQueue];
+  const quantity = parseFloat(el.orderItemQuantity.value);
+
+  if (!isNaN(quantity)) {
+    const existingItemIndex = state.currentOrder.items.findIndex(i => i.id === item.id);
+    if (existingItemIndex > -1) {
+      state.currentOrder.items[existingItemIndex].quantity = quantity;
+    } else {
+      state.currentOrder.items.push({ id: item.id, name: item.name, quantity });
+    }
+  }
+
+  runtime.positionInQueue++;
+  if (runtime.positionInQueue < runtime.itemsToCountQueue.length) {
+    displayCurrentOrderItem();
+  } else {
+    el.orderItem.classList.add('hidden');
+    el.orderSummary.classList.remove('hidden');
+  }
+}
+
+export function initOrders() {
   const { el } = getDOM();
 
   el.startOrderingBtn?.addEventListener('click', () => {
     state.currentOrder = { startedAt: Date.now(), items: [] };
+    runtime.itemsToCountQueue = [...state.masterItems];
+    runtime.positionInQueue = 0;
+    displayCurrentOrderItem();
     el.setupOrder?.classList.add('hidden');
     el.orderItem?.classList.remove('hidden');
     el.continueOrderBtn?.classList.remove('hidden');
     updateMenuButtons();
+  });
+
+  el.orderNextBtn?.addEventListener('click', nextOrderItem);
+
+  el.orderSkipBtn?.addEventListener('click', () => {
+    runtime.positionInQueue++;
+    if (runtime.positionInQueue < runtime.itemsToCountQueue.length) {
+      displayCurrentOrderItem();
+    } else {
+      el.orderItem.classList.add('hidden');
+      el.orderSummary.classList.remove('hidden');
+    }
+  });
+
+  el.orderNoPedirBtn?.addEventListener('click', () => {
+    const item = runtime.itemsToCountQueue[runtime.positionInQueue];
+    const existingItemIndex = state.currentOrder.items.findIndex(i => i.id === item.id);
+    if (existingItemIndex > -1) {
+      state.currentOrder.items[existingItemIndex].quantity = 0;
+    } else {
+      state.currentOrder.items.push({ id: item.id, name: item.name, quantity: 0 });
+    }
+    nextOrderItem();
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^30.0.5"
+  },
+  "dependencies": {
+    "firebase": "^12.1.0"
   }
 }

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -1,3 +1,31 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('firebase/app', () => ({
+    initializeApp: jest.fn(),
+}));
+jest.unstable_mockModule('firebase/auth', () => ({
+    getAuth: jest.fn(),
+    signInWithPopup: jest.fn(),
+    GoogleAuthProvider: jest.fn(),
+    signOut: jest.fn(),
+    onAuthStateChanged: jest.fn(),
+    createUserWithEmailAndPassword: jest.fn(),
+    signInWithEmailAndPassword: jest.fn(),
+}));
+jest.unstable_mockModule('firebase/firestore', () => ({
+    getFirestore: jest.fn(),
+    doc: jest.fn(),
+    getDoc: jest.fn(),
+    setDoc: jest.fn(),
+    updateDoc: jest.fn(),
+    collection: jest.fn(),
+    onSnapshot: jest.fn(),
+    writeBatch: jest.fn(),
+    query: jest.fn(),
+    orderBy: jest.fn(),
+    deleteDoc: jest.fn(),
+}));
+
 test('initApp hides loading and shows login view', async () => {
   const createEl = (cls = '') => ({
     classList: {

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,3 +1,5 @@
+import { jest } from '@jest/globals';
+
 import { isAuthenticated } from '../js/auth.js';
 
 test('isAuthenticated returns true for user object', () => {

--- a/tests/history.test.js
+++ b/tests/history.test.js
@@ -1,5 +1,40 @@
-import { historyCount } from '../js/history.js';
+import { historyCount, addHistoryEntry, initHistory, renderHistory } from '../js/history.js';
+
+beforeEach(() => {
+  global.localStorage = {
+    store: {},
+    getItem(key) { return this.store[key]; },
+    setItem(key, val) { this.store[key] = String(val); }
+  };
+  global.document = {
+    getElementById: (id) => (id === 'history-list' ? { innerHTML: '', appendChild: () => {} } : null),
+    querySelectorAll: () => [],
+    createElement: () => ({ textContent: '', appendChild: () => {} })
+  };
+});
 
 test('historyCount returns number of entries', () => {
   expect(historyCount([1,2,3])).toBe(3);
+});
+
+test('addHistoryEntry stores data in state and localStorage', async () => {
+  const { state } = await import('../js/state.js');
+  state.history = [];
+  await initHistory();
+  await addHistoryEntry({ title: 'Pedido 1' });
+  expect(state.history).toHaveLength(1);
+  expect(JSON.parse(global.localStorage.getItem('history'))).toHaveLength(1);
+});
+
+test('renderHistory outputs entries to DOM', async () => {
+  const list = { innerHTML: '', appendChild: () => { list.innerHTML += 'x'; } };
+  global.document = {
+    getElementById: (id) => (id === 'history-list' ? list : null),
+    querySelectorAll: () => [],
+    createElement: () => ({ textContent: '', appendChild: () => {} })
+  };
+  global.localStorage.setItem('history', JSON.stringify([{ title: 'Pedido 1' }]));
+  await initHistory();
+  renderHistory();
+  expect(list.innerHTML).not.toBe('');
 });

--- a/tests/inventory.test.js
+++ b/tests/inventory.test.js
@@ -1,6 +1,41 @@
-import { calculateInventoryValue } from '../js/inventory.js';
+import { jest } from '@jest/globals';
 
-test('calculateInventoryValue sums quantities', () => {
+const createEl = (visible = false) => ({
+  classList: {
+    classes: new Set(visible ? [] : ['hidden']),
+    add(c) { this.classes.add(c); },
+    remove(c) { this.classes.delete(c); },
+    contains(c) { return this.classes.has(c); }
+  }
+});
+
+test('calculateInventoryValue sums quantities', async () => {
+  const { calculateInventoryValue } = await import('../js/inventory.js');
   const items = [{ quantity: 2 }, { quantity: 3 }];
   expect(calculateInventoryValue(items)).toBe(5);
+});
+
+test('initInventory starts inventory and shows item view', async () => {
+  jest.resetModules();
+  let startClick;
+  const setup = createEl(true);
+  const item = createEl(false);
+  const continueInventoryBtn = createEl(false);
+  const el = {
+    startCountingBtn: { addEventListener: (_, cb) => { startClick = cb; } },
+    setup,
+    item,
+    continueInventoryBtn
+  };
+  jest.unstable_mockModule('../js/elements.js', () => ({ getDOM: () => ({ el }) }));
+  jest.unstable_mockModule('../js/app.js', () => ({ updateMenuButtons: jest.fn() }));
+  const { state } = await import('../js/state.js');
+  state.currentInventory = null;
+  const { initInventory } = await import('../js/inventory.js');
+  await initInventory();
+  startClick();
+  expect(state.currentInventory).not.toBeNull();
+  expect(setup.classList.contains('hidden')).toBe(true);
+  expect(item.classList.contains('hidden')).toBe(false);
+  expect(continueInventoryBtn.classList.contains('hidden')).toBe(false);
 });

--- a/tests/inventory.test.js
+++ b/tests/inventory.test.js
@@ -25,14 +25,43 @@ test('initInventory starts inventory and shows item view', async () => {
     startCountingBtn: { addEventListener: (_, cb) => { startClick = cb; } },
     setup,
     item,
-    continueInventoryBtn
+    continueInventoryBtn,
+    itemName: {},
+    itemCounter: {},
+    itemQuantity: {}
   };
   jest.unstable_mockModule('../js/elements.js', () => ({ getDOM: () => ({ el }) }));
   jest.unstable_mockModule('../js/app.js', () => ({ updateMenuButtons: jest.fn() }));
+  jest.unstable_mockModule('firebase/app', () => ({
+    initializeApp: jest.fn(),
+  }));
+    jest.unstable_mockModule('firebase/auth', () => ({
+        getAuth: jest.fn(),
+        signInWithPopup: jest.fn(),
+        GoogleAuthProvider: jest.fn(),
+        signOut: jest.fn(),
+        onAuthStateChanged: jest.fn(),
+        createUserWithEmailAndPassword: jest.fn(),
+        signInWithEmailAndPassword: jest.fn(),
+    }));
+    jest.unstable_mockModule('firebase/firestore', () => ({
+        getFirestore: jest.fn(),
+        doc: jest.fn(),
+        getDoc: jest.fn(),
+        setDoc: jest.fn(),
+        updateDoc: jest.fn(),
+        collection: jest.fn(),
+        onSnapshot: jest.fn(),
+        writeBatch: jest.fn(),
+        query: jest.fn(),
+        orderBy: jest.fn(),
+        deleteDoc: jest.fn(),
+    }));
   const { state } = await import('../js/state.js');
   state.currentInventory = null;
+  state.masterItems = [{ id: '1', name: 'Test Item', order: 0 }];
   const { initInventory } = await import('../js/inventory.js');
-  await initInventory();
+  initInventory();
   startClick();
   expect(state.currentInventory).not.toBeNull();
   expect(setup.classList.contains('hidden')).toBe(true);

--- a/tests/menu.test.js
+++ b/tests/menu.test.js
@@ -1,15 +1,24 @@
 import { jest } from '@jest/globals';
 
-test('history button shows history view and back returns to menu', async () => {
-  const createEl = (visible = false) => ({
-    classList: {
-      classes: new Set(visible ? [] : ['hidden']),
-      add(c) { this.classes.add(c); },
-      remove(c) { this.classes.delete(c); },
-      contains(c) { return this.classes.has(c); }
+const createEl = (visible = false) => ({
+  classList: {
+    classes: new Set(visible ? [] : ['hidden']),
+    add(c) { this.classes.add(c); },
+    remove(c) { this.classes.delete(c); },
+    contains(c) { return this.classes.has(c); },
+    toggle(c, force) {
+      if (force) {
+        this.classes.add(c);
+      } else {
+        this.classes.delete(c);
+      }
     }
-  });
+  },
+  addEventListener: () => {}
+});
 
+test('history button shows history view and back returns to menu', async () => {
+  jest.resetModules();
   const mainMenu = createEl(true);
   const history = createEl(false);
   const setup = createEl(false);
@@ -19,7 +28,6 @@ test('history button shows history view and back returns to menu', async () => {
 
   let historyClick;
   let backClick;
-  const dummyBtn = () => ({ addEventListener: () => {} });
 
   const el = {
     mainMenu,
@@ -28,23 +36,28 @@ test('history button shows history view and back returns to menu', async () => {
     setupOrder,
     consumptionSetup,
     manageItems,
-    startNewInventoryBtn: dummyBtn(),
-    continueInventoryBtn: dummyBtn(),
-    makeOrderBtn: dummyBtn(),
-    continueOrderBtn: dummyBtn(),
-    consumptionReportBtn: dummyBtn(),
+    startNewInventoryBtn: createEl(),
+    continueInventoryBtn: createEl(),
+    makeOrderBtn: createEl(),
+    continueOrderBtn: createEl(),
+    consumptionReportBtn: createEl(),
     historyBtn: { addEventListener: (_, cb) => { historyClick = cb; } },
-    manageItemsBtn: dummyBtn(),
+    manageItemsBtn: createEl(),
     backToMenuFromHistoryBtn: { addEventListener: (_, cb) => { backClick = cb; } },
-    backToMenuFromManageBtn: dummyBtn(),
-    backToMenuFromSelectInvBtn: dummyBtn(),
-    backToMenuFromConsumptionBtn: dummyBtn(),
+    backToMenuFromManageBtn: createEl(),
+    backToMenuFromSelectInvBtn: createEl(),
+    backToMenuFromConsumptionBtn: createEl(),
   };
 
   const allViews = [mainMenu, history, setup, setupOrder, consumptionSetup, manageItems];
 
   jest.unstable_mockModule('../js/elements.js', () => ({
     getDOM: () => ({ el, allViews })
+  }));
+  const renderHistory = jest.fn();
+  jest.unstable_mockModule('../js/history.js', () => ({
+    renderHistory,
+    initHistory: jest.fn()
   }));
 
   global.document = {
@@ -55,13 +68,63 @@ test('history button shows history view and back returns to menu', async () => {
   const { setupMenu } = await import('../js/app.js');
   setupMenu();
 
-  // Simulate clicking history button
   historyClick();
+  expect(renderHistory).toHaveBeenCalled();
   expect(mainMenu.classList.contains('hidden')).toBe(true);
   expect(history.classList.contains('hidden')).toBe(false);
 
-  // Simulate clicking back to menu
   backClick();
   expect(mainMenu.classList.contains('hidden')).toBe(false);
   expect(history.classList.contains('hidden')).toBe(true);
+});
+
+test('continue buttons hidden when no active sessions', async () => {
+  jest.resetModules();
+  const mainMenu = createEl(true);
+  const history = createEl(false);
+  const setup = createEl(false);
+  const setupOrder = createEl(false);
+  const consumptionSetup = createEl(false);
+  const manageItems = createEl(false);
+
+  const el = {
+    mainMenu,
+    history,
+    setup,
+    setupOrder,
+    consumptionSetup,
+    manageItems,
+    startNewInventoryBtn: createEl(),
+    continueInventoryBtn: createEl(true),
+    makeOrderBtn: createEl(),
+    continueOrderBtn: createEl(true),
+    consumptionReportBtn: createEl(),
+    historyBtn: createEl(),
+    manageItemsBtn: createEl(),
+    backToMenuFromHistoryBtn: createEl(),
+    backToMenuFromManageBtn: createEl(),
+    backToMenuFromSelectInvBtn: createEl(),
+    backToMenuFromConsumptionBtn: createEl(),
+  };
+
+  const allViews = [mainMenu, history, setup, setupOrder, consumptionSetup, manageItems];
+
+  jest.unstable_mockModule('../js/elements.js', () => ({
+    getDOM: () => ({ el, allViews })
+  }));
+  jest.unstable_mockModule('../js/history.js', () => ({ renderHistory: jest.fn(), initHistory: jest.fn() }));
+  const { state } = await import('../js/state.js');
+  state.currentInventory = null;
+  state.currentOrder = null;
+
+  global.document = {
+    addEventListener: () => {},
+    getElementById: () => ({ textContent: '' })
+  };
+
+  const { setupMenu } = await import('../js/app.js');
+  setupMenu();
+
+  expect(el.continueInventoryBtn.classList.contains('hidden')).toBe(true);
+  expect(el.continueOrderBtn.classList.contains('hidden')).toBe(true);
 });

--- a/tests/menu.test.js
+++ b/tests/menu.test.js
@@ -17,6 +17,32 @@ const createEl = (visible = false) => ({
   addEventListener: () => {}
 });
 
+jest.unstable_mockModule('firebase/app', () => ({
+    initializeApp: jest.fn(),
+}));
+jest.unstable_mockModule('firebase/auth', () => ({
+    getAuth: jest.fn(),
+    signInWithPopup: jest.fn(),
+    GoogleAuthProvider: jest.fn(),
+    signOut: jest.fn(),
+    onAuthStateChanged: jest.fn(),
+    createUserWithEmailAndPassword: jest.fn(),
+    signInWithEmailAndPassword: jest.fn(),
+}));
+jest.unstable_mockModule('firebase/firestore', () => ({
+    getFirestore: jest.fn(),
+    doc: jest.fn(),
+    getDoc: jest.fn(),
+    setDoc: jest.fn(),
+    updateDoc: jest.fn(),
+    collection: jest.fn(),
+    onSnapshot: jest.fn(),
+    writeBatch: jest.fn(),
+    query: jest.fn(),
+    orderBy: jest.fn(),
+    deleteDoc: jest.fn(),
+}));
+
 test('history button shows history view and back returns to menu', async () => {
   jest.resetModules();
   const mainMenu = createEl(true);

--- a/tests/orders.test.js
+++ b/tests/orders.test.js
@@ -1,6 +1,41 @@
-import { pendingOrders } from '../js/orders.js';
+import { jest } from '@jest/globals';
 
-test('pendingOrders filters out completed orders', () => {
+const createEl = (visible = false) => ({
+  classList: {
+    classes: new Set(visible ? [] : ['hidden']),
+    add(c) { this.classes.add(c); },
+    remove(c) { this.classes.delete(c); },
+    contains(c) { return this.classes.has(c); }
+  }
+});
+
+test('pendingOrders filters out completed orders', async () => {
+  const { pendingOrders } = await import('../js/orders.js');
   const orders = [{ completed: false }, { completed: true }];
   expect(pendingOrders(orders)).toHaveLength(1);
+});
+
+test('initOrders starts order and shows item view', async () => {
+  jest.resetModules();
+  let startClick;
+  const setupOrder = createEl(true);
+  const orderItem = createEl(false);
+  const continueOrderBtn = createEl(false);
+  const el = {
+    startOrderingBtn: { addEventListener: (_, cb) => { startClick = cb; } },
+    setupOrder,
+    orderItem,
+    continueOrderBtn
+  };
+  jest.unstable_mockModule('../js/elements.js', () => ({ getDOM: () => ({ el }) }));
+  jest.unstable_mockModule('../js/app.js', () => ({ updateMenuButtons: jest.fn() }));
+  const { state } = await import('../js/state.js');
+  state.currentOrder = null;
+  const { initOrders } = await import('../js/orders.js');
+  await initOrders();
+  startClick();
+  expect(state.currentOrder).not.toBeNull();
+  expect(setupOrder.classList.contains('hidden')).toBe(true);
+  expect(orderItem.classList.contains('hidden')).toBe(false);
+  expect(continueOrderBtn.classList.contains('hidden')).toBe(false);
 });

--- a/tests/orders.test.js
+++ b/tests/orders.test.js
@@ -25,14 +25,43 @@ test('initOrders starts order and shows item view', async () => {
     startOrderingBtn: { addEventListener: (_, cb) => { startClick = cb; } },
     setupOrder,
     orderItem,
-    continueOrderBtn
+    continueOrderBtn,
+    orderItemName: {},
+    orderItemCounter: {},
+    orderItemQuantity: {}
   };
   jest.unstable_mockModule('../js/elements.js', () => ({ getDOM: () => ({ el }) }));
   jest.unstable_mockModule('../js/app.js', () => ({ updateMenuButtons: jest.fn() }));
+  jest.unstable_mockModule('firebase/app', () => ({
+    initializeApp: jest.fn(),
+  }));
+    jest.unstable_mockModule('firebase/auth', () => ({
+        getAuth: jest.fn(),
+        signInWithPopup: jest.fn(),
+        GoogleAuthProvider: jest.fn(),
+        signOut: jest.fn(),
+        onAuthStateChanged: jest.fn(),
+        createUserWithEmailAndPassword: jest.fn(),
+        signInWithEmailAndPassword: jest.fn(),
+    }));
+    jest.unstable_mockModule('firebase/firestore', () => ({
+        getFirestore: jest.fn(),
+        doc: jest.fn(),
+        getDoc: jest.fn(),
+        setDoc: jest.fn(),
+        updateDoc: jest.fn(),
+        collection: jest.fn(),
+        onSnapshot: jest.fn(),
+        writeBatch: jest.fn(),
+        query: jest.fn(),
+        orderBy: jest.fn(),
+        deleteDoc: jest.fn(),
+    }));
   const { state } = await import('../js/state.js');
   state.currentOrder = null;
+  state.masterItems = [{ id: '1', name: 'Test Item', order: 0 }];
   const { initOrders } = await import('../js/orders.js');
-  await initOrders();
+  initOrders();
   startClick();
   expect(state.currentOrder).not.toBeNull();
   expect(setupOrder.classList.contains('hidden')).toBe(true);


### PR DESCRIPTION
## Summary
- hide continue options unless an inventory or order is active
- start inventory or order sessions and expose their first screens
- test inventory and order starts plus menu visibility logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d1525efd4832dadf6db97dcc2bb2c