### PR TITLE
feat: restore inventory and order flows

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,14 +1,21 @@
 import { initAuth } from './auth.js';
 import { initInventory } from './inventory.js';
 import { initOrders } from './orders.js';
-import { initHistory } from './history.js';
+import { initHistory, renderHistory } from './history.js';
 import { APP_VERSION } from './version.js';
 import { getDOM } from './elements.js';
+import { state } from './state.js';
 
 export function initApp() {
   const { el } = getDOM();
   el.loadingView.classList.add('hidden');
   el.loginView.classList.remove('hidden');
+}
+
+export function updateMenuButtons() {
+  const { el } = getDOM();
+  el.continueInventoryBtn?.classList.toggle('hidden', !state.currentInventory);
+  el.continueOrderBtn?.classList.toggle('hidden', !state.currentOrder);
 }
 
 export function setupMenu() {
@@ -18,18 +25,23 @@ export function setupMenu() {
     view.classList.remove('hidden');
   };
 
-  el.startNewInventoryBtn.addEventListener('click', () => show(el.setup));
-  el.continueInventoryBtn.addEventListener('click', () => show(el.setup));
-  el.makeOrderBtn.addEventListener('click', () => show(el.setupOrder));
-  el.continueOrderBtn.addEventListener('click', () => show(el.setupOrder));
-  el.consumptionReportBtn.addEventListener('click', () => show(el.consumptionSetup));
-  el.historyBtn.addEventListener('click', () => show(el.history));
-  el.manageItemsBtn.addEventListener('click', () => show(el.manageItems));
+  updateMenuButtons();
 
-  el.backToMenuFromHistoryBtn.addEventListener('click', () => show(el.mainMenu));
-  el.backToMenuFromManageBtn.addEventListener('click', () => show(el.mainMenu));
-  el.backToMenuFromSelectInvBtn.addEventListener('click', () => show(el.mainMenu));
-  el.backToMenuFromConsumptionBtn.addEventListener('click', () => show(el.mainMenu));
+  el.startNewInventoryBtn?.addEventListener('click', () => show(el.setup));
+  el.continueInventoryBtn?.addEventListener('click', () => show(el.setup));
+  el.makeOrderBtn?.addEventListener('click', () => show(el.setupOrder));
+  el.continueOrderBtn?.addEventListener('click', () => show(el.setupOrder));
+  el.consumptionReportBtn?.addEventListener('click', () => show(el.consumptionSetup));
+  el.historyBtn?.addEventListener('click', () => {
+    renderHistory();
+    show(el.history);
+  });
+  el.manageItemsBtn?.addEventListener('click', () => show(el.manageItems));
+
+  el.backToMenuFromHistoryBtn?.addEventListener('click', () => { show(el.mainMenu); updateMenuButtons(); });
+  el.backToMenuFromManageBtn?.addEventListener('click', () => { show(el.mainMenu); updateMenuButtons(); });
+  el.backToMenuFromSelectInvBtn?.addEventListener('click', () => { show(el.mainMenu); updateMenuButtons(); });
+  el.backToMenuFromConsumptionBtn?.addEventListener('click', () => { show(el.mainMenu); updateMenuButtons(); });
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/js/auth.js
+++ b/js/auth.js
@@ -26,14 +26,18 @@ export async function initAuth() {
     el.loginError.textContent = '';
   };
 
-  el.authToggleBtn.addEventListener('click', () => {
+  el.authToggleBtn?.addEventListener('click', () => {
     runtime.isLoginMode = !runtime.isLoginMode;
     updateMode();
   });
 
-  el.authActionBtn.addEventListener('click', async () => {
-    const email = el.emailInput.value.trim();
-    const password = el.passwordInput.value;
+  el.authActionBtn?.addEventListener('click', async () => {
+    const email = el.emailInput?.value.trim();
+    const password = el.passwordInput?.value;
+    if (!email || !password) {
+      el.loginError.textContent = 'Completa todos los campos';
+      return;
+    }
     try {
       if (runtime.isLoginMode) {
         await signInWithEmailAndPassword(auth, email, password);
@@ -45,19 +49,19 @@ export async function initAuth() {
     }
   });
 
-  el.logoutBtn.addEventListener('click', () => signOut(auth));
+  el.logoutBtn?.addEventListener('click', () => signOut(auth));
 
   onAuthStateChanged(auth, (user) => {
     if (user) {
       runtime.userId = user.uid;
-      el.userEmail.textContent = user.email;
-      el.loginView.classList.add('hidden');
-      el.mainContent.classList.remove('hidden');
+      if (el.userEmail) el.userEmail.textContent = user.email;
+      el.loginView?.classList.add('hidden');
+      el.mainContent?.classList.remove('hidden');
     } else {
       runtime.userId = null;
-      el.userEmail.textContent = '';
-      el.mainContent.classList.add('hidden');
-      el.loginView.classList.remove('hidden');
+      if (el.userEmail) el.userEmail.textContent = '';
+      el.mainContent?.classList.add('hidden');
+      el.loginView?.classList.remove('hidden');
     }
   });
 

--- a/js/history.js
+++ b/js/history.js
@@ -1,7 +1,50 @@
-export function initHistory() {
-  console.log('History initialized');
+let renderFn;
+
+export async function initHistory() {
+  const { state } = await import('./state.js');
+  const { getDOM } = await import('./elements.js');
+
+  try {
+    const stored = localStorage.getItem('history');
+    state.history = stored ? JSON.parse(stored) : [];
+  } catch {
+    state.history = [];
+  }
+
+  const render = () => {
+    const { el } = getDOM();
+    if (!el?.historyList) return;
+    el.historyList.innerHTML = '';
+    if (state.history.length === 0) {
+      const empty = document.createElement('div');
+      empty.textContent = 'Sin historial disponible';
+      el.historyList.appendChild(empty);
+      return;
+    }
+    state.history.forEach(entry => {
+      const item = document.createElement('div');
+      item.textContent = entry?.title || entry?.date || 'Historial';
+      el.historyList.appendChild(item);
+    });
+  };
+
+  renderFn = render;
+  renderFn();
+}
+
+export function renderHistory() {
+  if (typeof renderFn === 'function') {
+    renderFn();
+  }
 }
 
 export function historyCount(entries = []) {
   return entries.length;
+}
+
+export async function addHistoryEntry(entry) {
+  const { state } = await import('./state.js');
+  state.history.push(entry);
+  localStorage.setItem('history', JSON.stringify(state.history));
+  renderHistory();
 }

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1,5 +1,103 @@
-export function initInventory() {
-  console.log('Inventory initialized');
+export async function initInventory() {
+  const { getDOM } = await import('./elements.js');
+  const { state, runtime } = await import('./state.js');
+  const { updateMenuButtons } = await import('./app.js');
+  const { addHistoryEntry } = await import('./history.js');
+
+  const { el } = getDOM();
+
+  const loadItems = () => {
+    try {
+      const stored = localStorage.getItem('masterItems');
+      if (stored) {
+        state.masterItems = JSON.parse(stored);
+      }
+    } catch {
+      state.masterItems = [];
+    }
+    if (!state.masterItems || state.masterItems.length === 0) {
+      state.masterItems = [
+        { name: 'Item 1' },
+        { name: 'Item 2' }
+      ];
+    }
+  };
+
+  const showCurrent = () => {
+    const current = runtime.itemsToCountQueue[runtime.currentIndex];
+    if (!current) return;
+    if (el.itemName) el.itemName.textContent = current.name;
+    if (el.itemCounter) {
+      el.itemCounter.textContent = `Ítem ${runtime.currentIndex + 1}/${runtime.itemsToCountQueue.length}`;
+    }
+    if (el.itemQuantity) el.itemQuantity.value = current.quantity ?? '';
+  };
+
+  const renderSummary = () => {
+    if (!el.summaryList) return;
+    el.summaryList.innerHTML = '';
+    runtime.itemsToCountQueue.forEach(it => {
+      const row = document.createElement('div');
+      row.textContent = `${it.name}: ${it.quantity ?? 'N/A'}`;
+      el.summaryList.appendChild(row);
+    });
+  };
+
+  const finishInventory = () => {
+    state.currentInventory.items = runtime.itemsToCountQueue.slice();
+    addHistoryEntry({
+      type: 'inventory',
+      date: new Date().toISOString(),
+      title: 'Inventario',
+      items: state.currentInventory.items
+    });
+    el.item?.classList.add('hidden');
+    el.summary?.classList.remove('hidden');
+    renderSummary();
+    el.saveAndFinishBtn?.addEventListener('click', () => {
+      state.currentInventory = null;
+      el.summary?.classList.add('hidden');
+      el.mainMenu?.classList.remove('hidden');
+      updateMenuButtons();
+    }, { once: true });
+  };
+
+  const recordAndNext = (quantity) => {
+    runtime.itemsToCountQueue[runtime.currentIndex].quantity = quantity;
+    runtime.currentIndex++;
+    if (runtime.currentIndex < runtime.itemsToCountQueue.length) {
+      showCurrent();
+    } else {
+      finishInventory();
+    }
+  };
+
+  loadItems();
+
+  el.startCountingBtn?.addEventListener('click', () => {
+    state.currentInventory = { startedAt: Date.now(), items: [] };
+    runtime.itemsToCountQueue = state.masterItems.map(i => ({ name: i.name || i, quantity: null }));
+    runtime.currentIndex = 0;
+    el.setup?.classList.add('hidden');
+    el.item?.classList.remove('hidden');
+    el.continueInventoryBtn?.classList.remove('hidden');
+    showCurrent();
+    updateMenuButtons();
+  });
+
+  el.nextBtn?.addEventListener('click', () => {
+    const val = parseFloat(el.itemQuantity?.value);
+    recordAndNext(isNaN(val) ? null : val);
+  });
+
+  el.skipBtn?.addEventListener('click', () => recordAndNext(null));
+  el.naBtn?.addEventListener('click', () => recordAndNext(null));
+
+  el.backToCountBtn?.addEventListener('click', () => {
+    el.summary?.classList.add('hidden');
+    el.item?.classList.remove('hidden');
+    showCurrent();
+  });
 }
 
 export function calculateInventoryValue(items = []) {

--- a/js/orders.js
+++ b/js/orders.js
@@ -1,5 +1,108 @@
-export function initOrders() {
-  console.log('Orders initialized');
+export async function initOrders() {
+  const { getDOM } = await import('./elements.js');
+  const { state, runtime } = await import('./state.js');
+  const { updateMenuButtons } = await import('./app.js');
+  const { addHistoryEntry } = await import('./history.js');
+
+  const { el } = getDOM();
+
+  const loadItems = () => {
+    try {
+      const stored = localStorage.getItem('masterItems');
+      if (stored) state.masterItems = JSON.parse(stored);
+    } catch {
+      state.masterItems = [];
+    }
+    if (!state.masterItems || state.masterItems.length === 0) {
+      state.masterItems = [
+        { name: 'Item 1' },
+        { name: 'Item 2' }
+      ];
+    }
+  };
+
+  const showCurrent = () => {
+    const current = runtime.itemsToCountQueue[runtime.currentIndex];
+    if (!current) return;
+    if (el.orderItemName) el.orderItemName.textContent = current.name;
+    if (el.orderItemCounter) {
+      el.orderItemCounter.textContent = `Ítem ${runtime.currentIndex + 1}/${runtime.itemsToCountQueue.length}`;
+    }
+    if (el.orderItemQuantity) el.orderItemQuantity.value = current.quantity ?? '';
+    if (el.orderItemStock) el.orderItemStock.textContent = current.stock ?? 0;
+  };
+
+  const renderSummary = () => {
+    if (!el.orderSummaryList) return;
+    el.orderSummaryList.innerHTML = '';
+    runtime.itemsToCountQueue.forEach(it => {
+      const row = document.createElement('div');
+      row.textContent = `${it.name}: ${it.quantity ?? 0}`;
+      el.orderSummaryList.appendChild(row);
+    });
+  };
+
+  const finishOrder = () => {
+    state.currentOrder.items = runtime.itemsToCountQueue.slice();
+    addHistoryEntry({
+      type: 'order',
+      date: new Date().toISOString(),
+      title: 'Pedido',
+      items: state.currentOrder.items
+    });
+    el.orderItem?.classList.add('hidden');
+    el.orderSummary?.classList.remove('hidden');
+    renderSummary();
+    el.saveOrderBtn?.addEventListener('click', () => {
+      state.currentOrder = null;
+      el.orderSummary?.classList.add('hidden');
+      el.mainMenu?.classList.remove('hidden');
+      updateMenuButtons();
+    }, { once: true });
+  };
+
+  const recordAndNext = (quantity) => {
+    runtime.itemsToCountQueue[runtime.currentIndex].quantity = quantity;
+    runtime.currentIndex++;
+    if (runtime.currentIndex < runtime.itemsToCountQueue.length) {
+      showCurrent();
+    } else {
+      finishOrder();
+    }
+  };
+
+  loadItems();
+
+  el.startOrderingBtn?.addEventListener('click', () => {
+    state.currentOrder = { startedAt: Date.now(), items: [] };
+    runtime.itemsToCountQueue = state.masterItems.map(i => ({ name: i.name || i, quantity: null, stock: 0 }));
+    runtime.currentIndex = 0;
+    el.setupOrder?.classList.add('hidden');
+    el.orderItem?.classList.remove('hidden');
+    el.continueOrderBtn?.classList.remove('hidden');
+    showCurrent();
+    updateMenuButtons();
+  });
+
+  el.orderNextBtn?.addEventListener('click', () => {
+    const val = parseFloat(el.orderItemQuantity?.value);
+    recordAndNext(isNaN(val) ? 0 : val);
+  });
+
+  el.orderSkipBtn?.addEventListener('click', () => recordAndNext(0));
+  el.orderNoPedirBtn?.addEventListener('click', () => recordAndNext(0));
+
+  el.backToOrderBtn?.addEventListener('click', () => {
+    el.orderSummary?.classList.add('hidden');
+    el.orderItem?.classList.remove('hidden');
+    showCurrent();
+  });
+
+  el.backToSelectInvBtn?.addEventListener('click', () => {
+    el.setupOrder?.classList.add('hidden');
+    el.mainMenu?.classList.remove('hidden');
+    updateMenuButtons();
+  });
 }
 
 export function pendingOrders(orders = []) {

--- a/tests/history.test.js
+++ b/tests/history.test.js
@@ -1,5 +1,40 @@
-import { historyCount } from '../js/history.js';
+import { historyCount, addHistoryEntry, initHistory, renderHistory } from '../js/history.js';
+
+beforeEach(() => {
+  global.localStorage = {
+    store: {},
+    getItem(key) { return this.store[key]; },
+    setItem(key, val) { this.store[key] = String(val); }
+  };
+  global.document = {
+    getElementById: (id) => (id === 'history-list' ? { innerHTML: '', appendChild: () => {} } : null),
+    querySelectorAll: () => [],
+    createElement: () => ({ textContent: '', appendChild: () => {} })
+  };
+});
 
 test('historyCount returns number of entries', () => {
   expect(historyCount([1,2,3])).toBe(3);
+});
+
+test('addHistoryEntry stores data in state and localStorage', async () => {
+  const { state } = await import('../js/state.js');
+  state.history = [];
+  await initHistory();
+  await addHistoryEntry({ title: 'Pedido 1' });
+  expect(state.history).toHaveLength(1);
+  expect(JSON.parse(global.localStorage.getItem('history'))).toHaveLength(1);
+});
+
+test('renderHistory outputs entries to DOM', async () => {
+  const list = { innerHTML: '', appendChild: () => { list.innerHTML += 'x'; } };
+  global.document = {
+    getElementById: (id) => (id === 'history-list' ? list : null),
+    querySelectorAll: () => [],
+    createElement: () => ({ textContent: '', appendChild: () => {} })
+  };
+  global.localStorage.setItem('history', JSON.stringify([{ title: 'Pedido 1' }]));
+  await initHistory();
+  renderHistory();
+  expect(list.innerHTML).not.toBe('');
 });

--- a/tests/inventory.test.js
+++ b/tests/inventory.test.js
@@ -1,6 +1,62 @@
-import { calculateInventoryValue } from '../js/inventory.js';
+import { jest } from '@jest/globals';
 
-test('calculateInventoryValue sums quantities', () => {
+const createEl = (visible = false) => ({
+  classList: {
+    classes: new Set(visible ? [] : ['hidden']),
+    add(c) { this.classes.add(c); },
+    remove(c) { this.classes.delete(c); },
+    contains(c) { return this.classes.has(c); }
+  }
+});
+
+test('calculateInventoryValue sums quantities', async () => {
+  const { calculateInventoryValue } = await import('../js/inventory.js');
   const items = [{ quantity: 2 }, { quantity: 3 }];
   expect(calculateInventoryValue(items)).toBe(5);
+});
+
+test('initInventory starts inventory and shows item view', async () => {
+  jest.resetModules();
+  let startClick;
+  const setup = createEl(true);
+  const item = createEl(false);
+  const summary = createEl(false);
+  const continueInventoryBtn = createEl(false);
+  const itemName = { textContent: '' };
+  const itemCounter = { textContent: '' };
+  const itemQuantity = { value: '' };
+  const nextBtn = { addEventListener: (_, cb) => { /* ignore */ } };
+  const summaryList = { innerHTML: '', appendChild: () => {} };
+  const saveAndFinishBtn = { addEventListener: () => {} };
+  const el = {
+    startCountingBtn: { addEventListener: (_, cb) => { startClick = cb; } },
+    setup,
+    item,
+    summary,
+    continueInventoryBtn,
+    itemName,
+    itemCounter,
+    itemQuantity,
+    nextBtn,
+    summaryList,
+    saveAndFinishBtn,
+    mainMenu: createEl()
+  };
+  global.localStorage = {
+    store: { masterItems: JSON.stringify([{ name: 'Test Item' }]) },
+    getItem(k) { return this.store[k]; },
+    setItem(k, v) { this.store[k] = String(v); }
+  };
+  jest.unstable_mockModule('../js/elements.js', () => ({ getDOM: () => ({ el }) }));
+  jest.unstable_mockModule('../js/app.js', () => ({ updateMenuButtons: jest.fn() }));
+  const { state } = await import('../js/state.js');
+  state.currentInventory = null;
+  const { initInventory } = await import('../js/inventory.js');
+  await initInventory();
+  startClick();
+  expect(state.currentInventory).not.toBeNull();
+  expect(itemName.textContent).toBe('Test Item');
+  expect(setup.classList.contains('hidden')).toBe(true);
+  expect(item.classList.contains('hidden')).toBe(false);
+  expect(continueInventoryBtn.classList.contains('hidden')).toBe(false);
 });

--- a/tests/menu.test.js
+++ b/tests/menu.test.js
@@ -1,15 +1,24 @@
 import { jest } from '@jest/globals';
 
-test('history button shows history view and back returns to menu', async () => {
-  const createEl = (visible = false) => ({
-    classList: {
-      classes: new Set(visible ? [] : ['hidden']),
-      add(c) { this.classes.add(c); },
-      remove(c) { this.classes.delete(c); },
-      contains(c) { return this.classes.has(c); }
+const createEl = (visible = false) => ({
+  classList: {
+    classes: new Set(visible ? [] : ['hidden']),
+    add(c) { this.classes.add(c); },
+    remove(c) { this.classes.delete(c); },
+    contains(c) { return this.classes.has(c); },
+    toggle(c, force) {
+      if (force) {
+        this.classes.add(c);
+      } else {
+        this.classes.delete(c);
+      }
     }
-  });
+  },
+  addEventListener: () => {}
+});
 
+test('history button shows history view and back returns to menu', async () => {
+  jest.resetModules();
   const mainMenu = createEl(true);
   const history = createEl(false);
   const setup = createEl(false);
@@ -19,7 +28,6 @@ test('history button shows history view and back returns to menu', async () => {
 
   let historyClick;
   let backClick;
-  const dummyBtn = () => ({ addEventListener: () => {} });
 
   const el = {
     mainMenu,
@@ -28,23 +36,28 @@ test('history button shows history view and back returns to menu', async () => {
     setupOrder,
     consumptionSetup,
     manageItems,
-    startNewInventoryBtn: dummyBtn(),
-    continueInventoryBtn: dummyBtn(),
-    makeOrderBtn: dummyBtn(),
-    continueOrderBtn: dummyBtn(),
-    consumptionReportBtn: dummyBtn(),
+    startNewInventoryBtn: createEl(),
+    continueInventoryBtn: createEl(),
+    makeOrderBtn: createEl(),
+    continueOrderBtn: createEl(),
+    consumptionReportBtn: createEl(),
     historyBtn: { addEventListener: (_, cb) => { historyClick = cb; } },
-    manageItemsBtn: dummyBtn(),
+    manageItemsBtn: createEl(),
     backToMenuFromHistoryBtn: { addEventListener: (_, cb) => { backClick = cb; } },
-    backToMenuFromManageBtn: dummyBtn(),
-    backToMenuFromSelectInvBtn: dummyBtn(),
-    backToMenuFromConsumptionBtn: dummyBtn(),
+    backToMenuFromManageBtn: createEl(),
+    backToMenuFromSelectInvBtn: createEl(),
+    backToMenuFromConsumptionBtn: createEl(),
   };
 
   const allViews = [mainMenu, history, setup, setupOrder, consumptionSetup, manageItems];
 
   jest.unstable_mockModule('../js/elements.js', () => ({
     getDOM: () => ({ el, allViews })
+  }));
+  const renderHistory = jest.fn();
+  jest.unstable_mockModule('../js/history.js', () => ({
+    renderHistory,
+    initHistory: jest.fn()
   }));
 
   global.document = {
@@ -55,13 +68,63 @@ test('history button shows history view and back returns to menu', async () => {
   const { setupMenu } = await import('../js/app.js');
   setupMenu();
 
-  // Simulate clicking history button
   historyClick();
+  expect(renderHistory).toHaveBeenCalled();
   expect(mainMenu.classList.contains('hidden')).toBe(true);
   expect(history.classList.contains('hidden')).toBe(false);
 
-  // Simulate clicking back to menu
   backClick();
   expect(mainMenu.classList.contains('hidden')).toBe(false);
   expect(history.classList.contains('hidden')).toBe(true);
+});
+
+test('continue buttons hidden when no active sessions', async () => {
+  jest.resetModules();
+  const mainMenu = createEl(true);
+  const history = createEl(false);
+  const setup = createEl(false);
+  const setupOrder = createEl(false);
+  const consumptionSetup = createEl(false);
+  const manageItems = createEl(false);
+
+  const el = {
+    mainMenu,
+    history,
+    setup,
+    setupOrder,
+    consumptionSetup,
+    manageItems,
+    startNewInventoryBtn: createEl(),
+    continueInventoryBtn: createEl(true),
+    makeOrderBtn: createEl(),
+    continueOrderBtn: createEl(true),
+    consumptionReportBtn: createEl(),
+    historyBtn: createEl(),
+    manageItemsBtn: createEl(),
+    backToMenuFromHistoryBtn: createEl(),
+    backToMenuFromManageBtn: createEl(),
+    backToMenuFromSelectInvBtn: createEl(),
+    backToMenuFromConsumptionBtn: createEl(),
+  };
+
+  const allViews = [mainMenu, history, setup, setupOrder, consumptionSetup, manageItems];
+
+  jest.unstable_mockModule('../js/elements.js', () => ({
+    getDOM: () => ({ el, allViews })
+  }));
+  jest.unstable_mockModule('../js/history.js', () => ({ renderHistory: jest.fn(), initHistory: jest.fn() }));
+  const { state } = await import('../js/state.js');
+  state.currentInventory = null;
+  state.currentOrder = null;
+
+  global.document = {
+    addEventListener: () => {},
+    getElementById: () => ({ textContent: '' })
+  };
+
+  const { setupMenu } = await import('../js/app.js');
+  setupMenu();
+
+  expect(el.continueInventoryBtn.classList.contains('hidden')).toBe(true);
+  expect(el.continueOrderBtn.classList.contains('hidden')).toBe(true);
 });

--- a/tests/orders.test.js
+++ b/tests/orders.test.js
@@ -1,6 +1,62 @@
-import { pendingOrders } from '../js/orders.js';
+import { jest } from '@jest/globals';
 
-test('pendingOrders filters out completed orders', () => {
+const createEl = (visible = false) => ({
+  classList: {
+    classes: new Set(visible ? [] : ['hidden']),
+    add(c) { this.classes.add(c); },
+    remove(c) { this.classes.delete(c); },
+    contains(c) { return this.classes.has(c); }
+  }
+});
+
+test('pendingOrders filters out completed orders', async () => {
+  const { pendingOrders } = await import('../js/orders.js');
   const orders = [{ completed: false }, { completed: true }];
   expect(pendingOrders(orders)).toHaveLength(1);
+});
+
+test('initOrders starts order and shows item view', async () => {
+  jest.resetModules();
+  let startClick;
+  const setupOrder = createEl(true);
+  const orderItem = createEl(false);
+  const orderSummary = createEl(false);
+  const continueOrderBtn = createEl(false);
+  const orderItemName = { textContent: '' };
+  const orderItemCounter = { textContent: '' };
+  const orderItemQuantity = { value: '' };
+  const orderNextBtn = { addEventListener: (_, cb) => { /* ignore */ } };
+  const orderSummaryList = { innerHTML: '', appendChild: () => {} };
+  const saveOrderBtn = { addEventListener: () => {} };
+  const el = {
+    startOrderingBtn: { addEventListener: (_, cb) => { startClick = cb; } },
+    setupOrder,
+    orderItem,
+    orderSummary,
+    continueOrderBtn,
+    orderItemName,
+    orderItemCounter,
+    orderItemQuantity,
+    orderNextBtn,
+    orderSummaryList,
+    saveOrderBtn,
+    mainMenu: createEl()
+  };
+  global.localStorage = {
+    store: { masterItems: JSON.stringify([{ name: 'Order Item' }]) },
+    getItem(k) { return this.store[k]; },
+    setItem(k, v) { this.store[k] = String(v); }
+  };
+  jest.unstable_mockModule('../js/elements.js', () => ({ getDOM: () => ({ el }) }));
+  jest.unstable_mockModule('../js/app.js', () => ({ updateMenuButtons: jest.fn() }));
+  const { state } = await import('../js/state.js');
+  state.currentOrder = null;
+  const { initOrders } = await import('../js/orders.js');
+  await initOrders();
+  startClick();
+  expect(state.currentOrder).not.toBeNull();
+  expect(orderItemName.textContent).toBe('Order Item');
+  expect(setupOrder.classList.contains('hidden')).toBe(true);
+  expect(orderItem.classList.contains('hidden')).toBe(false);
+  expect(continueOrderBtn.classList.contains('hidden')).toBe(false);
 });


### PR DESCRIPTION
## Summary
- populate inventory and order sessions from master items and show current item details
- record quantities, render summaries and persist to history
- add navigation and tests for restored inventory and order flows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d1525efd4832dadf6db97dcc2bb2c